### PR TITLE
Fix deprecation notice by replacing all occurrences of "thumbs-o-up" with "far-thumbs-up"

### DIFF
--- a/common/header.html
+++ b/common/header.html
@@ -1,9 +1,9 @@
 <script type="text/discourse-plugin" version="0.8">
       api.replaceIcon('d-liked', 'thumbs-up');
-      api.replaceIcon('d-unliked', 'thumbs-o-up');
-      api.replaceIcon('notification.liked', 'thumbs-o-up');
-      api.replaceIcon('notification.liked_2', 'thumbs-o-up');
-      api.replaceIcon('notification.liked_many', 'thumbs-o-up');
-      api.replaceIcon('notification.liked_consolidated', 'thumbs-o-up');      
+      api.replaceIcon('d-unliked', 'far-thumbs-up');
+      api.replaceIcon('notification.liked', 'far-thumbs-up');
+      api.replaceIcon('notification.liked_2', 'far-thumbs-up');
+      api.replaceIcon('notification.liked_many', 'far-thumbs-up');
+      api.replaceIcon('notification.liked_consolidated', 'far-thumbs-up');      
       api.replaceIcon('heart', 'thumbs-up');
 </script>


### PR DESCRIPTION
Original notice:

`Deprecation notice: Please replace all occurrences of "thumbs-o-up"" with "far-thumbs-up". FontAwesome 4.7 icon names are now deprecated and will be removed in the next release.`